### PR TITLE
Allow `N_` as a decorator

### DIFF
--- a/lib/rubocop/cop/i18n/gettext/decorate_function_message.rb
+++ b/lib/rubocop/cop/i18n/gettext/decorate_function_message.rb
@@ -4,7 +4,7 @@ module RuboCop
       module GetText
         class DecorateFunctionMessage < Cop
           SUPPORTED_METHODS = ['raise', 'fail']
-          SUPPORTED_DECORATORS = ["_", 'n_']
+          SUPPORTED_DECORATORS = ['_', 'n_', 'N_']
 
           def on_send(node)
             method_name = node.loc.selector.source

--- a/spec/rubocop/cop/i18n/gettext/decorate_function_message_spec.rb
+++ b/spec/rubocop/cop/i18n/gettext/decorate_function_message_spec.rb
@@ -35,6 +35,7 @@ describe RuboCop::Cop::I18n::GetText::DecorateFunctionMessage do
       it_behaves_like 'a_detecting_cop', "#{function}(\"a string \#{var}\")", function, 'message should use correctly formatted interpolation'
       #it_behaves_like 'a_fixing_cop', "#{function}(\"a string \#{var}\")", "#{function}(_(\"a string %{value0}\") % { value0: var, })", function
       it_behaves_like 'a_no_cop_required', "#{function}(_(\"a string %{value0}\")) % { value0: var, }", function
+      it_behaves_like 'a_no_cop_required', "#{function}(N_(\"a string %s\"))", function
     end
     context "#{function} message not decorated, but does not hit interpolation / concatenation / multi-line / simple-string" do
       it_behaves_like 'a_detecting_cop', "fail print('kittens')", function, 'message should be decorated'


### PR DESCRIPTION
`N_` tells `gettext` that the string needs translation and adds it to `.po` file (without substituting it with the localized string).