### PR TITLE
(PUP-8038) Make DecorateString look for actual sentences

### DIFF
--- a/lib/rubocop/cop/i18n/gettext/decorate_string.rb
+++ b/lib/rubocop/cop/i18n/gettext/decorate_string.rb
@@ -4,25 +4,27 @@ module RuboCop
   module Cop
     module I18n
       module GetText
-        # This cop checks for butt or ass,
-        # which is redundant.
-        #
+        # This cop checks for sentence-like strings that are undecorated
         # @example
         #
         #   # bad
         #
-        #   "result is #{something.to_s}"
+        #   "The result is success."
         #
         # @example
         #
         #   # good
         #
-        #   "result is #{something}"
+        #   _("The result is success.")
         class DecorateString < Cop
+          SUPPORTED_DECORATORS = ['_', 'n_', 'N_']
+
           def on_str(node)
+            return if node.parent && supported_decorator_name?(node.parent.method_name.to_s)
             str = node.children[0]
-            #ignore strings with no whitespace - are typically keywords or interpolation statements and cover the above commented-out statements
-            if str !~ /^\S*$/
+
+            # look for strings starting with a capitalized letter, followed by some spaces and other characters, and then some punctuation.
+            if str =~ /^[[:upper:]][[:alpha:]]*[[:blank:]]+.*[.!?]$/
               add_offense(node, :expression, "decorator is missing around sentence") if node.loc.respond_to?(:begin)
             end
           end
@@ -33,6 +35,9 @@ module RuboCop
             node.receiver ? MSG_DEFAULT : MSG_SELF
           end
 
+          def supported_decorator_name?(decorator_name)
+            SUPPORTED_DECORATORS.include?(decorator_name)
+          end
         end
       end
     end

--- a/spec/rubocop/cop/i18n/gettext/decorate_string_spec.rb
+++ b/spec/rubocop/cop/i18n/gettext/decorate_string_spec.rb
@@ -8,10 +8,10 @@ describe RuboCop::Cop::I18n::GetText::DecorateString do
   # For some reason, this string isn't considered decorated.
   #it_behaves_like 'accepts', '_("a string")'
 
-  context 'undecorated string' do
+  context 'undecorated sentence' do
     let(:source) {
 <<-RUBY
-"a string"
+"A grammatically correct sentence contains punctuation."
 RUBY
     }
 
@@ -19,6 +19,72 @@ RUBY
       investigate(cop, source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses[0].message).to match(/decorator is missing around sentence/)
+    end
+  end
+
+  context 'undecorated sentences' do
+    let(:source) {
+<<-RUBY
+"A grammatically correct sentence contains punctuation. This string contains two of them."
+RUBY
+    }
+
+    it 'rejects' do
+      investigate(cop, source)
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.offenses[0].message).to match(/decorator is missing around sentence/)
+    end
+  end
+
+  context 'decorated sentence' do
+    let(:source) {
+<<-RUBY
+_("A grammatically correct sentence contains punctuation.")
+RUBY
+    }
+
+    it 'accepts' do
+      investigate(cop, source)
+      expect(cop.offenses.size).to eq(0)
+    end
+  end
+
+  context 'decorated sentence' do
+    let(:source) {
+<<-RUBY
+_("A grammatically correct sentence contains punctuation. This string contains two of them.")
+RUBY
+    }
+
+    it 'accepts' do
+      investigate(cop, source)
+      expect(cop.offenses.size).to eq(0)
+    end
+  end
+
+  context 'string with no capitalization or punctuation' do
+    let(:source) {
+<<-RUBY
+"a grammatically incorrect sentence with no punctuation is not what this library is concerned with"
+RUBY
+    }
+
+    it 'accepts' do
+      investigate(cop, source)
+      expect(cop.offenses.size).to eq(0)
+    end
+  end
+
+  context 'string with no starting capitalization' do
+    let(:source) {
+<<-RUBY
+"a grammatically incorrect sentence is not what this library is concerned with."
+RUBY
+    }
+
+    it 'accepts' do
+      investigate(cop, source)
+      expect(cop.offenses.size).to eq(0)
     end
   end
 end


### PR DESCRIPTION
Prior to this commit DecorateString would look for any string
with spaces in it, which is way too overzealous.
This commit refines DecorateString to look for strings containing
something closer to a real sentence with the first letter capitalized
and containing some punctuation.