### PR TITLE
(PUP-8038) Update DecorateString to look for sentences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Change log
+
+## master (unreleased)
+
+### 1.2.0
+
+ * Updated DecorateString to look for sentences using a regular expression that should be decorated. 
+This limits the number of strings that it finds to things that look like a sentence.
+
+### 1.1.0
+
+ * Added support for DecorateStringFormattingUsingPercent
+ * Added support for DecorateStringFormattingUsingInterpolation
+
+### 1.0.0
+
+ * Improvements to DecorateFunctionMessage
+
+### 0.0.1
+
+ * Initial import of rubocop rules from https://github.com/tphoney/puppetlabs-mysql/tree/poc_i18nTesting/rubocop by [@tphoney]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ require:
  - rubocop-i18n
 ...
 GetText/DecorateString:
-  Enabled: false
+  Enabled: true
 GetText/DecorateFunctionMessage:
   Enabled: true
 GetText/DecorateStringFormattingUsingInterpolation
@@ -36,6 +36,42 @@ GetText/DecorateStringFormattingUsingPercent
 ```
 
 ## Cops
+
+### GetText/DecorateString
+
+This cop is looks for strings that appear to be sentences but are not decorated. 
+Sentences are determined by the STRING_REGEXP.
+
+##### Error message thrown 
+
+```
+decorator is missing around string, instead found <method>
+```
+or
+```
+decorator is missing around string
+```
+
+##### Bad
+
+``` ruby
+"Result is bad."
+```
+
+##### Good
+
+``` ruby
+_("Result is good.")
+```
+
+##### Ignored
+``` ruby
+"string"
+"A string with out a punctuation at the end"
+"a string that doesn't start with a capital letter."
+```
+
+
 
 ### GetText/DecorateFunctionMessage
 
@@ -207,6 +243,7 @@ raise(_("Warning is %{value}") % { value: 'bad' })
 
 It may be necessary to ignore a cop for a particular piece of code. We follow standard rubocop idioms.
 ``` ruby
+raise("We don't want this translated.")  # rubocop:disable GetText/DecorateString
 raise("We don't want this translated")  # rubocop:disable GetText/DecorateFunctionMessage
 raise(_("We don't want this translated #{crazy}")  # rubocop:disable GetText/DecorateStringFormattingUsingInterpolation)
 raise(_("We don't want this translated %s") % ['crazy'] # rubocop:disable GetText/DecorateStringFormattingUsingPercent)

--- a/lib/rubocop/cop/i18n/gettext/decorate_string.rb
+++ b/lib/rubocop/cop/i18n/gettext/decorate_string.rb
@@ -4,33 +4,77 @@ module RuboCop
   module Cop
     module I18n
       module GetText
-        # This cop checks for butt or ass,
-        # which is redundant.
+        # This cop is looks for strings that appear to be sentences but are not decorated.
+        # Sentences are determined by the STRING_REGEXP. (Upper case character, at least one space,
+        # and sentence punctuation at the end)
         #
         # @example
         #
         #   # bad
         #
-        #   "result is #{something.to_s}"
+        #   "Result is bad."
         #
         # @example
         #
         #   # good
         #
-        #   "result is #{something}"
+        #   _("Result is good.")
         class DecorateString < Cop
-          def on_str(node)
-            str = node.children[0]
-            #ignore strings with no whitespace - are typically keywords or interpolation statements and cover the above commented-out statements
-            if str !~ /^\S*$/
-              add_offense(node, :expression, "decorator is missing around sentence") if node.loc.respond_to?(:begin)
+
+          SUPPORTED_DECORATORS = ['_', 'n_', 'N_']
+          STRING_REGEXP = /^\s*[[:upper:]][[:alpha:]]*[[:blank:]]+.*[.!?]$/
+
+          def on_dstr(node)
+            if dstr_contains_sentence?(node)
+              check_for_parent_decorator(node)
             end
+          end
+
+          def on_str(node)
+            return unless is_sentence?(node)
+
+            parent = node.parent
+            # ignore regexp expressions and dstr is covered by on_dstr
+            if parent.regexp_type? or parent.dstr_type?
+              return
+            end
+
+            check_for_parent_decorator(node)
           end
 
           private
 
-          def message(node)
-            node.receiver ? MSG_DEFAULT : MSG_SELF
+          def is_sentence?(node)
+            child = node.children[0]
+            if child.is_a?(String)
+              if child.valid_encoding?
+                child.chomp.force_encoding(Encoding::UTF_8) =~ STRING_REGEXP
+              else
+                false
+              end
+            elsif child.respond_to?(:str_type?) and child.str_type?
+              is_sentence?(child)
+            else
+              false
+            end
+          end
+
+          def dstr_contains_sentence?(node)
+            node.children.any? { |child| is_sentence?(child) }
+          end
+
+          def check_for_parent_decorator(node)
+            parent = node.parent
+            if parent.send_type?
+              method_name = parent.loc.selector.source
+              unless SUPPORTED_DECORATORS.include?(method_name)
+                add_offense(node, :expression, "decorator is missing around string, instead found #{method_name}")
+              end
+            elsif parent.method_name == :[]
+              return
+            else
+              add_offense(node, :expression, "decorator is missing around string")
+            end
           end
 
         end

--- a/rubocop-i18n.gemspec
+++ b/rubocop-i18n.gemspec
@@ -4,9 +4,9 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-i18n"
-  spec.version       = '1.1.0'
-  spec.authors       = ["Brandon High", "TP Honey", "Helen Campbell"]
-  spec.email         = ["brandon.high@puppet.com", "tp@puppet.com", "helen@puppet.com"]
+  spec.version       = '1.2.0'
+  spec.authors       = ["Puppet", "Brandon High", "TP Honey", "Helen Campbell"]
+  spec.email         = ["team-modules@puppet.com", "brandon.high@puppet.com", "tp@puppet.com", "helen@puppet.com"]
 
   spec.summary       = %q{RuboCop rules for i18n}
   spec.description   = %q{RuboCop rules for detecting and autocorrecting undecorated strings for i18n}

--- a/spec/rubocop/cop/i18n/gettext/decorate_string_spec.rb
+++ b/spec/rubocop/cop/i18n/gettext/decorate_string_spec.rb
@@ -4,21 +4,69 @@ require 'spec_helper'
 describe RuboCop::Cop::I18n::GetText::DecorateString do
   let(:config) { RuboCop::Config.new }
   subject(:cop) { described_class.new(config) }
+  before(:each) {
+    investigate(cop, source)
+  }
 
-  # For some reason, this string isn't considered decorated.
-  #it_behaves_like 'accepts', '_("a string")'
+  context "decoration need for string" do
+    it_behaves_like 'a_detecting_cop', "a = \"A sentence that is not decorated.\"", '_', 'decorator is missing around string'
+    it_behaves_like 'a_detecting_cop', "thing(\"A sentence that is not decorated.\")", '_', 'decorator is missing around string'
+    it_behaves_like 'a_detecting_cop', "thing(\"A sentence that " + "is not decorated.\")", '_', 'decorator is missing around string'
+  end
 
-  context 'undecorated string' do
-    let(:source) {
-<<-RUBY
-"a string"
-RUBY
-    }
+  context "decoration not needed for string" do
+    it_behaves_like 'a_no_cop_required', "'keyword'"
+    # a regexp is a string
+    it_behaves_like 'a_no_cop_required', '@regexp = /[ =]/'
+    it_behaves_like 'a_no_cop_required', 'A sentence with out punctuation at the end'
+    it_behaves_like 'a_no_cop_required', 'stream.puts "#@version\n" if @version'
+    it_behaves_like 'a_no_cop_required', '
+          f.puts(<<-YAML)
+---
+:tag: yaml
+:yaml:
+   :something: #{variable}
+      YAML'
+  end
 
-    it 'rejects' do
-      investigate(cop, source)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses[0].message).to match(/decorator is missing around sentence/)
+  context "decoration not needed for a hash key" do
+    # a string as an hash key is ok
+    it_behaves_like 'a_no_cop_required', 'memo["#{class_path}##{method}-#{source_line}"] += 1'
+  end
+
+  context "string with invalid UTF-8" do
+    it_behaves_like 'a_no_cop_required', '
+        STRING_MAP = {
+      Encoding::UTF_8 => "\uFFFD",
+      Encoding::UTF_16LE => "\xFD\xFF".force_encoding(Encoding::UTF_16LE),
+    }'
+  end
+
+  context "decoration missing for dstr" do
+    it_behaves_like 'a_detecting_cop', "b = \"A sentence line one.
+      line two\"", '_', 'decorator is missing around string'
+    it_behaves_like 'a_detecting_cop', "b = \"line one.
+      A sentence line two.\"", '_', 'decorator is missing around string'
+  end
+
+  decorators = ['_', 'n_', 'N_']
+  decorators.each do |decorator|
+
+    context "#{decorator} already present" do
+      it_behaves_like 'a_no_cop_required', "#{decorator}('a string')"
+      it_behaves_like 'a_no_cop_required', "#{decorator} \"a string\""
+      it_behaves_like 'a_no_cop_required', "a = #{decorator}('a string')"
+      it_behaves_like 'a_no_cop_required', "#{decorator}(\"a %-5.2.s thing s string\")"
+      it_behaves_like 'a_no_cop_required', "Log.warning #{decorator}(\"could not change to group %{group}: %{detail}\") % { group: group, detail: detail }"
+      it_behaves_like 'a_no_cop_required', "Log.warning #{decorator}(\"could not change to group %{group}: %{detail}\") % { group: #{decorator}(\"group\"), detail: #{decorator}(\"detail\") }"
     end
+
+    context "#{decorator} around dstr" do
+      it_behaves_like 'a_no_cop_required', "a = #{decorator}(\"A sentence line one.
+        line two\")"
+      it_behaves_like 'a_no_cop_required', "a = #{decorator}(\"line one.
+        A sentence line two.\")"
+    end
+
   end
 end

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -17,6 +17,18 @@ shared_examples 'a_detecting_cop' do |unfixed, function, expected_warning|
   it 'has the correct number of offenses' do
     expect(cop.offenses.size).to eq(1)
   end
+  end
+
+shared_examples 'a_multiple_detecting_cop' do |unfixed, function, expected_warning|
+  let(:source) { "#{unfixed}" }
+  it 'has the correct rubocop warning' do
+    expect(cop.offenses[0]).not_to be_nil
+    expect(cop.offenses[0].message).to include(expected_warning)
+  end
+
+  it 'has the correct number of offenses' do
+    expect(cop.offenses.size).to be >= 1
+  end
 end
 
 shared_examples 'a_no_cop_required' do |fixed, function|


### PR DESCRIPTION
Updated DecorateString cop to look for strings that match a regular expression for a basic
sentence. This greatly reduces the number of strings that the cop expects to be decorated.

   'A sentence that should be decorated.'