### PR TITLE
Relax rubocop constraint

### DIFF
--- a/rubocop-i18n.gemspec
+++ b/rubocop-i18n.gemspec
@@ -2,7 +2,7 @@
 
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-rubocop_version = '~> 0.49.0'
+rubocop_version = '~> 0.49'
 
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-i18n'


### PR DESCRIPTION
Relax rubocop constraint so that projects using rubocop-i18n can use a more recent rubocop version, eg 0.56.0.