### PR TITLE
Add autocorrect for GetText/DecorateString

### DIFF
--- a/lib/rubocop/cop/i18n/gettext/decorate_string.rb
+++ b/lib/rubocop/cop/i18n/gettext/decorate_string.rb
@@ -37,6 +37,10 @@ module RuboCop
             check_for_parent_decorator(node)
           end
 
+          def autocorrect(node)
+            single_string_correct(node) if node.str_type?
+          end
+
           private
 
           def sentence?(node)
@@ -67,6 +71,13 @@ module RuboCop
               return
             end
             add_offense(node, message: 'decorator is missing around sentence')
+          end
+
+          def single_string_correct(node)
+            lambda { |corrector|
+              corrector.insert_before(node.source_range, '_(')
+              corrector.insert_after(node.source_range, ')')
+            }
           end
         end
       end

--- a/lib/rubocop/cop/i18n/gettext/decorate_string.rb
+++ b/lib/rubocop/cop/i18n/gettext/decorate_string.rb
@@ -63,7 +63,7 @@ module RuboCop
             if parent.respond_to?(:type) && parent.send_type?
               method_name = parent.loc.selector.source
               return if GetText.supported_decorator?(method_name)
-            elsif parent.respond_to?(:method_name) && parent.method_name == :[]
+            elsif parent.respond_to?(:method_name) && parent.method?(:[])
               return
             end
             add_offense(node, message: 'decorator is missing around sentence')

--- a/lib/rubocop/cop/i18n/rails_i18n/decorate_string.rb
+++ b/lib/rubocop/cop/i18n/rails_i18n/decorate_string.rb
@@ -149,13 +149,13 @@ module RuboCop
             return true if parent.respond_to?(:method_name) && %i[raise fail].include?(parent.method_name)
 
             # Commonly exceptions are initialized manually.
-            return ignoring_raised_parent?(parent.parent) if parent.respond_to?(:method_name) && parent.method_name == :new
+            return ignoring_raised_parent?(parent.parent) if parent.respond_to?(:method_name) && parent.method?(:new)
 
             false
           end
 
           def parent_is_indexer?(parent)
-            parent.respond_to?(:method_name) && parent.method_name == :[]
+            parent.respond_to?(:method_name) && parent.method?(:[])
           end
 
           def parent_is_translator?(parent)

--- a/spec/rubocop/cop/i18n/gettext/decorate_string_spec.rb
+++ b/spec/rubocop/cop/i18n/gettext/decorate_string_spec.rb
@@ -12,6 +12,7 @@ describe RuboCop::Cop::I18n::GetText::DecorateString do
   context 'decoration needed for string' do
     it_behaves_like 'a_detecting_cop', 'a = "A sentence that is not decorated."', '_', 'decorator is missing around sentence'
     it_behaves_like 'a_detecting_cop', 'thing("A sentence that is not decorated.")', '_', 'decorator is missing around sentence'
+    it_behaves_like 'a_fixing_cop', 'thing("A sentence that is not decorated.")', 'thing(_("A sentence that is not decorated."))', 'thing'
   end
 
   context 'decoration not needed for string' do


### PR DESCRIPTION
This adds simple autocorrect functionality to GetText/DecorateString, similar to that implemented in GetText/DecorateFunctionMessage.