### PR TITLE
[UPDATE] gems' version dependency

### DIFF
--- a/rubocop-i18n.gemspec
+++ b/rubocop-i18n.gemspec
@@ -2,7 +2,7 @@
 
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-rubocop_version = '~> 0.51'
+rubocop_version = '>= 1.0'
 
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-i18n'


### PR DESCRIPTION
In a `Gemfile` if you use Rubocop 1.2, you face an issue to install this gem:
```
rubocop-i18n (~> 2.0, >= 2.0.2) was resolved to 2.0.2, which depends on
  rubocop (~> 0.51)
```

According to [the gem documentation](https://guides.rubygems.org/specification-reference/#required_ruby_version=) I propose to update the version of rubocop in the `rubocop-i18n.gemspec` file.

Tested on `Fedora 32` with `ruby --version ruby 2.6.5p114 (2019-10-01 revision 67812) [x86_64-linux]`.