### PR TITLE
2021 02 26 fix rubocop 1.10 linter issues

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ require:
 
 AllCops:
   TargetRubyVersion: 2.5
+  NewCops: enable
 
 Metrics/BlockLength:
   Exclude:

--- a/lib/rubocop/cop/i18n/rails_i18n/decorate_string.rb
+++ b/lib/rubocop/cop/i18n/rails_i18n/decorate_string.rb
@@ -122,7 +122,7 @@ module RuboCop
             when 'sentence'            then SENTENCE_REGEXP
             when 'fragmented_sentence' then FRAGMENTED_SENTENCE_REGEXP
             when 'fragment'            then FRAGMENT_REGEXP
-            else
+            else # rubocop:disable Lint/DuplicateBranch
               SENTENCE_REGEXP
             end
           end

--- a/spec/rubocop/cop/i18n/gettext/decorate_function_message_spec.rb
+++ b/spec/rubocop/cop/i18n/gettext/decorate_function_message_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::I18n::GetText::DecorateFunctionMessage do
-  let(:config) { RuboCop::Config.new }
-  subject(:cop) { described_class.new(config) }
+describe RuboCop::Cop::I18n::GetText::DecorateFunctionMessage, :config, :config do
   before(:each) do
     investigate(cop, source)
   end

--- a/spec/rubocop/cop/i18n/gettext/decorate_string_formatting_using_interpolation_spec.rb
+++ b/spec/rubocop/cop/i18n/gettext/decorate_string_formatting_using_interpolation_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::I18n::GetText::DecorateStringFormattingUsingInterpolation do
-  let(:config) { RuboCop::Config.new }
-  subject(:cop) { described_class.new(config) }
+describe RuboCop::Cop::I18n::GetText::DecorateStringFormattingUsingInterpolation, :config, :config do
   before(:each) do
     investigate(cop, source)
   end

--- a/spec/rubocop/cop/i18n/gettext/decorate_string_formatting_using_percent_spec.rb
+++ b/spec/rubocop/cop/i18n/gettext/decorate_string_formatting_using_percent_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::I18n::GetText::DecorateStringFormattingUsingPercent do
-  let(:config) { RuboCop::Config.new }
-  subject(:cop) { described_class.new(config) }
+describe RuboCop::Cop::I18n::GetText::DecorateStringFormattingUsingPercent, :config, :config do
   before(:each) do
     investigate(cop, source)
   end

--- a/spec/rubocop/cop/i18n/gettext/decorate_string_spec.rb
+++ b/spec/rubocop/cop/i18n/gettext/decorate_string_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::I18n::GetText::DecorateString do
-  let(:config) { RuboCop::Config.new }
-  subject(:cop) { described_class.new(config) }
+describe RuboCop::Cop::I18n::GetText::DecorateString, :config, :config do
   before(:each) do
     investigate(cop, source)
   end

--- a/spec/rubocop/cop/i18n/rails_i18n/decorate_string_formatting_using_interpolation_spec.rb
+++ b/spec/rubocop/cop/i18n/rails_i18n/decorate_string_formatting_using_interpolation_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::I18n::RailsI18n::DecorateStringFormattingUsingInterpolation do
-  let(:config) { RuboCop::Config.new }
-  subject(:cop) { described_class.new(config) }
+describe RuboCop::Cop::I18n::RailsI18n::DecorateStringFormattingUsingInterpolation, :config, :config do
   before(:each) do
     investigate(cop, source)
   end

--- a/spec/rubocop/cop/i18n/rails_i18n/decorate_string_spec.rb
+++ b/spec/rubocop/cop/i18n/rails_i18n/decorate_string_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::I18n::RailsI18n::DecorateString do
-  let(:config) { RuboCop::Config.new }
-  subject(:cop) { described_class.new(config) }
+describe RuboCop::Cop::I18n::RailsI18n::DecorateString, :config, :config do
   before(:each) do
     investigate(cop, source)
   end


### PR DESCRIPTION
These changes should get the build passing again.