### PR TITLE
Add IgnoreLogger config

### DIFF
--- a/lib/rubocop/cop/i18n/rails_i18n/decorate_string.rb
+++ b/lib/rubocop/cop/i18n/rails_i18n/decorate_string.rb
@@ -28,6 +28,11 @@ module RuboCop
         #
         #   raise "Some string sentence"
         #
+        # @example IgnoreLogger: true
+        #   # OK
+        #
+        #   logger.info("Some string sentence")
+        #
         # @example EnforcedSentenceType: sentence
         #   # bad
         #
@@ -139,6 +144,7 @@ module RuboCop
             return if parent_is_translator?(node.parent)
             return if parent_is_indexer?(node.parent)
             return if ignoring_raised_parent?(node.parent)
+            return if ignoring_logger?(node.parent)
 
             add_offense(node, message: 'decorator is missing around sentence')
           end
@@ -150,6 +156,14 @@ module RuboCop
 
             # Commonly exceptions are initialized manually.
             return ignoring_raised_parent?(parent.parent) if parent.respond_to?(:method_name) && parent.method?(:new)
+
+            false
+          end
+
+          def ignoring_logger?(parent)
+            return false unless cop_config['IgnoreLogger']
+
+            return true if parent.respond_to?(:method_name) && %i[debug info warn error].include?(parent.method_name)
 
             false
           end

--- a/spec/rubocop/cop/i18n/rails_i18n/decorate_string_spec.rb
+++ b/spec/rubocop/cop/i18n/rails_i18n/decorate_string_spec.rb
@@ -118,6 +118,16 @@ describe RuboCop::Cop::I18n::RailsI18n::DecorateString, :config, :config do
     end
   end
 
+  context 'when ignoring logger' do
+    let(:config) do
+      RuboCop::Config.new('I18n/RailsI18n/DecorateString' => { 'IgnoreLogger' => true })
+    end
+
+    %w[debug info warn error].each do |type|
+      it_behaves_like 'a_no_cop_required', "#{type} \"A sentence that is not decorated.\""
+    end
+  end
+
   context 'when configuring a different regex' do
     let(:config) do
       RuboCop::Config.new('I18n/RailsI18n/DecorateString' => { 'Regexp' => '^test-test-test$' })


### PR DESCRIPTION
Hi! I don't know if you're currently accepting contributions, but just in case:

I've recently found this gem to be useful, and I have been using a monkey-patched version of DecorateString that ignores loggers.