### PR TITLE
Make custom cop inherit `RuboCop::Cop::Base`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,10 @@ AllCops:
   TargetRubyVersion: 2.5
   NewCops: enable
 
+# rubocop-i18n does not have config/default.
+InternalAffairs/UndefinedConfig:
+  Enabled: false
+
 Metrics/BlockLength:
   Exclude:
     # Exclude the spec directory because the rspec DSL results in long blocks

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -27,7 +27,7 @@ Metrics/AbcSize:
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 108
+  Max: 109
 
 # Offense count: 5
 # Configuration parameters: IgnoredMethods.

--- a/lib/rubocop/cop/i18n/gettext/decorate_string.rb
+++ b/lib/rubocop/cop/i18n/gettext/decorate_string.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module I18n
       module GetText
-        # This cop is looks for strings that appear to be sentences but are not decorated.
+        # Looks for strings that appear to be sentences but are not decorated.
         # Sentences are determined by the STRING_REGEXP. (Upper case character, at least one space,
         # and sentence punctuation at the end)
         #

--- a/lib/rubocop/cop/i18n/gettext/decorate_string.rb
+++ b/lib/rubocop/cop/i18n/gettext/decorate_string.rb
@@ -19,7 +19,9 @@ module RuboCop
         #   # good
         #
         #   _("Result is good.")
-        class DecorateString < Cop
+        class DecorateString < Base
+          extend AutoCorrector
+
           STRING_REGEXP = /^\s*[[:upper:]][[:alpha:]]*[[:blank:]]+.*[.!?]$/.freeze
 
           def on_dstr(node)
@@ -35,10 +37,6 @@ module RuboCop
             end
 
             check_for_parent_decorator(node)
-          end
-
-          def autocorrect(node)
-            single_string_correct(node) if node.str_type?
           end
 
           private
@@ -70,14 +68,13 @@ module RuboCop
             elsif parent.respond_to?(:method_name) && parent.method?(:[])
               return
             end
-            add_offense(node, message: 'decorator is missing around sentence')
+            add_offense(node, message: 'decorator is missing around sentence') do |corrector|
+              single_string_correct(corrector, node) if node.str_type?
+            end
           end
 
-          def single_string_correct(node)
-            lambda { |corrector|
-              corrector.insert_before(node.source_range, '_(')
-              corrector.insert_after(node.source_range, ')')
-            }
+          def single_string_correct(corrector, node)
+            corrector.wrap(node.source_range, '_(', ')')
           end
         end
       end

--- a/lib/rubocop/cop/i18n/gettext/decorate_string_formatting_using_interpolation.rb
+++ b/lib/rubocop/cop/i18n/gettext/decorate_string_formatting_using_interpolation.rb
@@ -22,7 +22,7 @@ module RuboCop
         #
         #   _("result is %{detail}" % {detail: message})
         #
-        class DecorateStringFormattingUsingInterpolation < Cop
+        class DecorateStringFormattingUsingInterpolation < Base
           def on_send(node)
             decorator_name = node.loc.selector.source
             return unless GetText.supported_decorator?(decorator_name)

--- a/lib/rubocop/cop/i18n/gettext/decorate_string_formatting_using_percent.rb
+++ b/lib/rubocop/cop/i18n/gettext/decorate_string_formatting_using_percent.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         #   _("result is %{detail}" % {detail: message})
         #
-        class DecorateStringFormattingUsingPercent < Cop
+        class DecorateStringFormattingUsingPercent < Base
           SUPPORTED_FORMATS = %w[b B d i o u x X e E f g G a A c p s].freeze
 
           def on_send(node)

--- a/lib/rubocop/cop/i18n/rails_i18n/decorate_string.rb
+++ b/lib/rubocop/cop/i18n/rails_i18n/decorate_string.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module I18n
       module RailsI18n
-        # This cop is looks for strings that appear to be sentences but are not decorated.
+        # Looks for strings that appear to be sentences but are not decorated.
         # Sentences are determined by the SENTENCE_REGEXP. (Upper case character, at least one space,
         # and sentence punctuation at the end)
         #

--- a/lib/rubocop/cop/i18n/rails_i18n/decorate_string.rb
+++ b/lib/rubocop/cop/i18n/rails_i18n/decorate_string.rb
@@ -70,7 +70,7 @@ module RuboCop
         #   "Any other string is fine now"
         #   t("only_this_text")
         #
-        class DecorateString < Cop
+        class DecorateString < Base
           SENTENCE_REGEXP = /^\s*[[:upper:]][[:alpha:]]*[[:blank:]]+.*[.!?]$/.freeze
           FRAGMENTED_SENTENCE_REGEXP = /^\s*([[:upper:]][[:alpha:]]*[[:blank:]]+.*)|([[:alpha:]]*[[:blank:]]+.*[.!?])$/.freeze
           FRAGMENT_REGEXP = /^\s*[[:alpha:]]*[[:blank:]]+.*$/.freeze

--- a/lib/rubocop/cop/i18n/rails_i18n/decorate_string_formatting_using_interpolation.rb
+++ b/lib/rubocop/cop/i18n/rails_i18n/decorate_string_formatting_using_interpolation.rb
@@ -20,7 +20,7 @@ module RuboCop
         #
         #   t("status.accepted")
         #
-        class DecorateStringFormattingUsingInterpolation < Cop
+        class DecorateStringFormattingUsingInterpolation < Base
           def on_send(node)
             return unless node&.loc&.selector
 

--- a/rubocop-i18n.gemspec
+++ b/rubocop-i18n.gemspec
@@ -23,6 +23,10 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.5.8'
 
+  spec.metadata = {
+    'rubygems_mfa_required' => 'true'
+  }
+
   spec.add_development_dependency 'bundler', '>= 1.17.3'
   spec.add_development_dependency 'pry', '~> 0.13.1'
   spec.add_development_dependency 'rake', '>= 12.3.3'

--- a/spec/rubocop/cop/i18n/gettext/decorate_function_message_spec.rb
+++ b/spec/rubocop/cop/i18n/gettext/decorate_function_message_spec.rb
@@ -2,9 +2,9 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::I18n::GetText::DecorateFunctionMessage, :config, :config do
+describe RuboCop::Cop::I18n::GetText::DecorateFunctionMessage, :config do
   before(:each) do
-    investigate(cop, source)
+    @offenses = investigate(cop, source)
   end
 
   RuboCop::Cop::I18n::GetText.supported_methods.each do |function|
@@ -52,13 +52,13 @@ describe RuboCop::Cop::I18n::GetText::DecorateFunctionMessage, :config, :config 
       let(:source) { "raise(Puppet::ParseError, \"mysql_password(): Wrong number of arguments \" \\\n \"given (\#{args.size} for 1)\")" }
 
       it 'has the correct error message' do
-        expect(cop.offenses[0]).not_to be_nil
-        expect(cop.offenses[0].message).to match(/message should not be a multi-line string/)
-        expect(cop.offenses[0].message).to match(/message should use correctly formatted interpolation/)
+        expect(@offenses[0]).not_to be_nil
+        expect(@offenses[0].message).to match(/message should not be a multi-line string/)
+        expect(@offenses[0].message).to match(/message should use correctly formatted interpolation/)
       end
 
       it 'has the correct number of offenses' do
-        expect(cop.offenses.size).to eq(1)
+        expect(@offenses.size).to eq(1)
       end
 
       it 'autocorrects', broken: true do

--- a/spec/rubocop/cop/i18n/gettext/decorate_string_formatting_using_interpolation_spec.rb
+++ b/spec/rubocop/cop/i18n/gettext/decorate_string_formatting_using_interpolation_spec.rb
@@ -2,9 +2,9 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::I18n::GetText::DecorateStringFormattingUsingInterpolation, :config, :config do
+describe RuboCop::Cop::I18n::GetText::DecorateStringFormattingUsingInterpolation, :config do
   before(:each) do
-    investigate(cop, source)
+    @offenses = investigate(cop, source)
   end
 
   RuboCop::Cop::I18n::GetText.supported_decorators.each do |decorator|

--- a/spec/rubocop/cop/i18n/gettext/decorate_string_formatting_using_percent_spec.rb
+++ b/spec/rubocop/cop/i18n/gettext/decorate_string_formatting_using_percent_spec.rb
@@ -2,9 +2,9 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::I18n::GetText::DecorateStringFormattingUsingPercent, :config, :config do
+describe RuboCop::Cop::I18n::GetText::DecorateStringFormattingUsingPercent, :config do
   before(:each) do
-    investigate(cop, source)
+    @offenses = investigate(cop, source)
   end
 
   RuboCop::Cop::I18n::GetText.supported_decorators.each do |decorator|

--- a/spec/rubocop/cop/i18n/gettext/decorate_string_spec.rb
+++ b/spec/rubocop/cop/i18n/gettext/decorate_string_spec.rb
@@ -2,9 +2,9 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::I18n::GetText::DecorateString, :config, :config do
+describe RuboCop::Cop::I18n::GetText::DecorateString, :config do
   before(:each) do
-    investigate(cop, source)
+    @offenses = investigate(cop, source)
   end
 
   context 'decoration needed for string' do

--- a/spec/rubocop/cop/i18n/rails_i18n/decorate_string_formatting_using_interpolation_spec.rb
+++ b/spec/rubocop/cop/i18n/rails_i18n/decorate_string_formatting_using_interpolation_spec.rb
@@ -2,9 +2,9 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::I18n::RailsI18n::DecorateStringFormattingUsingInterpolation, :config, :config do
+describe RuboCop::Cop::I18n::RailsI18n::DecorateStringFormattingUsingInterpolation, :config do
   before(:each) do
-    investigate(cop, source)
+    @offenses = investigate(cop, source)
   end
 
   RuboCop::Cop::I18n::RailsI18n.supported_decorators.each do |decorator|

--- a/spec/rubocop/cop/i18n/rails_i18n/decorate_string_spec.rb
+++ b/spec/rubocop/cop/i18n/rails_i18n/decorate_string_spec.rb
@@ -2,9 +2,9 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::I18n::RailsI18n::DecorateString, :config, :config do
+describe RuboCop::Cop::I18n::RailsI18n::DecorateString, :config do
   before(:each) do
-    investigate(cop, source)
+    @offenses = investigate(cop, source)
   end
 
   context 'decoration needed for string' do

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -6,27 +6,26 @@ shared_examples 'accepts' do |code|
   let(:source) { code }
 
   it 'does not register an offense' do
-    investigate(cop, source)
-    expect(cop.offenses).to be_empty
+    expect(@offenses).to be_empty
   end
 end
 
 shared_examples 'a_detecting_cop' do |unfixed, _function, expected_warning|
   let(:source) { unfixed.to_s }
   it 'has the correct rubocop warning' do
-    expect(cop.offenses[0]).not_to be_nil
-    expect(cop.offenses[0].message).to include(expected_warning)
+    expect(@offenses[0]).not_to be_nil
+    expect(@offenses[0].message).to include(expected_warning)
   end
 
   it 'has the correct number of offenses' do
-    expect(cop.offenses.size).to eq(1)
+    expect(@offenses.size).to eq(1)
   end
 end
 
 shared_examples 'a_no_cop_required' do |fixed, _function|
   let(:source) { fixed.to_s }
   it 'has no offenses found' do
-    expect(cop.offenses).to be_empty
+    expect(@offenses).to be_empty
   end
 end
 

--- a/spec/shared_functions.rb
+++ b/spec/shared_functions.rb
@@ -2,7 +2,7 @@
 
 def investigate(cop, src, filename = nil)
   processed_source = RuboCop::ProcessedSource.new(src, RUBY_VERSION.to_f, filename)
-  commissioner = RuboCop::Cop::Commissioner.new([cop], [], raise_error: true)
-  commissioner.investigate(processed_source)
-  commissioner
+  team = RuboCop::Cop::Team.new([cop], nil, raise_error: true)
+  report = team.investigate(processed_source)
+  report.offenses
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ RSpec.configure do |config|
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
   # get run.
-  unless defined?(::TestQueue)
+  unless defined?(TestQueue)
     # See. https://github.com/tmm1/test-queue/issues/60#issuecomment-281948929
     config.filter_run :focus
     config.run_all_when_everything_filtered = true
@@ -22,7 +22,7 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 
   broken_filter = lambda do |v|
-    v.is_a?(Symbol) ? RUBY_ENGINE == v.to_s : v
+    v.is_a?(Symbol) ? v.to_s == RUBY_ENGINE : v
   end
   config.filter_run_excluding broken: broken_filter
 


### PR DESCRIPTION
Follow https://github.com/rubocop/rubocop/pull/7868.

The legacy `Cop::Cop` API is soft deprecated and this PR use new `Cop::Base` API instead.

> maintain any RuboCop extensions, as the legacy API will be removed in RuboCop 2.0.

https://metaredux.com/posts/2020/10/21/rubocop-1-0.html

And this PR suppresses the following RuboCop offenses.

```console
Offenses:

lib/rubocop/cop/i18n/gettext/decorate_string.rb:7:11: C: InternalAffairs/CopDescription:
Description should be started with a word such as verb instead of This cop ....
        # This cop is looks for strings that appear to be sentences but are not decorated. ...
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/i18n/rails_i18n/decorate_string.rb:7:11: C: InternalAffairs/CopDescription:
Description should be started with a word such as verb instead of This cop ....
        # This cop is looks for strings that appear to be sentences but are not decorated. ...
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/i18n/rails_i18n/decorate_string.rb:121:29: C: InternalAffairs/UndefinedConfig:
EnforcedSentenceType is not defined in the configuration for I18n/RailsI18n/DecorateString in config/default.yml.
            case cop_config['EnforcedSentenceType'].to_s.downcase
                            ^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/i18n/rails_i18n/decorate_string.rb:131:35: C: InternalAffairs/UndefinedConfig:
Regexp is not defined in the configuration for I18n/RailsI18n/DecorateString in config/default.yml.
            Regexp.new(cop_config['Regexp']) if cop_config['Regexp']
                                  ^^^^^^^^
lib/rubocop/cop/i18n/rails_i18n/decorate_string.rb:131:60: C: InternalAffairs/UndefinedConfig:
Regexp is not defined in the configuration for I18n/RailsI18n/DecorateString in config/default.yml.
            Regexp.new(cop_config['Regexp']) if cop_config['Regexp']
                                                           ^^^^^^^^
lib/rubocop/cop/i18n/rails_i18n/decorate_string.rb:147:44: C: InternalAffairs/UndefinedConfig:
IgnoreExceptions is not defined in the configuration for I18n/RailsI18n/DecorateString in config/default.yml.
            return false unless cop_config['IgnoreExceptions']
                                           ^^^^^^^^^^^^^^^^^^
rubocop-i18n.gemspec:6:1: W: [Correctable] Gemspec/RequireMFA: metadata['rubygems_mfa_required'] must be set to 'true'.
Gem::Specification.new do |spec| ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/spec_helper.rb:13:19: C: [Correctable] Style/RedundantConstantBase: Remove redundant ::.
  unless defined?(::TestQueue)
                  ^^
spec/spec_helper.rb:25:23: C: [Correctable] Style/YodaCondition: Reverse the order of the operands RUBY_ENGINE == v.to_s.
    v.is_a?(Symbol) ? RUBY_ENGINE == v.to_s : v
                      ^^^^^^^^^^^^^^^^^^^^^

23 files inspected, 9 offenses detected, 3 offenses autocorrectable
```

NOTE: This commit make MFA enabled in rubocop-i18n.gemspec so releases to rubygems.org will require MFA.