### PR TITLE
Use `RuboCop::Cop::Base` instead of `RuboCop::Cop::Cop`

### DIFF
--- a/lib/rubocop/cop/i18n/gettext/decorate_function_message.rb
+++ b/lib/rubocop/cop/i18n/gettext/decorate_function_message.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module I18n
       module GetText
-        class DecorateFunctionMessage < Cop
+        class DecorateFunctionMessage < Base
           def on_send(node)
             method_name = node.loc.selector.source
             return unless GetText.supported_method?(method_name)

--- a/lib/rubocop/cop/i18n/gettext/decorate_string.rb
+++ b/lib/rubocop/cop/i18n/gettext/decorate_string.rb
@@ -19,7 +19,7 @@ module RuboCop
         #   # good
         #
         #   _("Result is good.")
-        class DecorateString < Cop
+        class DecorateString < Base
           STRING_REGEXP = /^\s*[[:upper:]][[:alpha:]]*[[:blank:]]+.*[.!?]$/.freeze
 
           def on_dstr(node)

--- a/lib/rubocop/cop/i18n/gettext/decorate_string_formatting_using_interpolation.rb
+++ b/lib/rubocop/cop/i18n/gettext/decorate_string_formatting_using_interpolation.rb
@@ -22,7 +22,7 @@ module RuboCop
         #
         #   _("result is %{detail}" % {detail: message})
         #
-        class DecorateStringFormattingUsingInterpolation < Cop
+        class DecorateStringFormattingUsingInterpolation < Base
           def on_send(node)
             decorator_name = node.loc.selector.source
             return unless GetText.supported_decorator?(decorator_name)

--- a/lib/rubocop/cop/i18n/gettext/decorate_string_formatting_using_percent.rb
+++ b/lib/rubocop/cop/i18n/gettext/decorate_string_formatting_using_percent.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         #   _("result is %{detail}" % {detail: message})
         #
-        class DecorateStringFormattingUsingPercent < Cop
+        class DecorateStringFormattingUsingPercent < Base
           SUPPORTED_FORMATS = %w[b B d i o u x X e E f g G a A c p s].freeze
 
           def on_send(node)

--- a/lib/rubocop/cop/i18n/rails_i18n/decorate_string.rb
+++ b/lib/rubocop/cop/i18n/rails_i18n/decorate_string.rb
@@ -70,7 +70,7 @@ module RuboCop
         #   "Any other string is fine now"
         #   t("only_this_text")
         #
-        class DecorateString < Cop
+        class DecorateString < Base
           SENTENCE_REGEXP = /^\s*[[:upper:]][[:alpha:]]*[[:blank:]]+.*[.!?]$/.freeze
           FRAGMENTED_SENTENCE_REGEXP = /^\s*([[:upper:]][[:alpha:]]*[[:blank:]]+.*)|([[:alpha:]]*[[:blank:]]+.*[.!?])$/.freeze
           FRAGMENT_REGEXP = /^\s*[[:alpha:]]*[[:blank:]]+.*$/.freeze

--- a/lib/rubocop/cop/i18n/rails_i18n/decorate_string_formatting_using_interpolation.rb
+++ b/lib/rubocop/cop/i18n/rails_i18n/decorate_string_formatting_using_interpolation.rb
@@ -20,7 +20,7 @@ module RuboCop
         #
         #   t("status.accepted")
         #
-        class DecorateStringFormattingUsingInterpolation < Cop
+        class DecorateStringFormattingUsingInterpolation < Base
           def on_send(node)
             return unless node&.loc&.selector
 


### PR DESCRIPTION
### Motivation / Background

`RuboCop::Cop::Cop` is deprecated, Use `RuboCop::Cop::Base` instead. [detail](https://docs.rubocop.org/rubocop/v1_upgrade_notes.html#base-class)