### PR TITLE
Fix an error when using `.call` shorthand syntax

### DIFF
--- a/lib/rubocop/cop/i18n/gettext/decorate_function_message.rb
+++ b/lib/rubocop/cop/i18n/gettext/decorate_function_message.rb
@@ -4,10 +4,14 @@ module RuboCop
   module Cop
     module I18n
       module GetText
+        # rubocop:disable Metrics/ClassLength
         class DecorateFunctionMessage < Base
           extend AutoCorrector
 
+          # rubocop:disable Metrics/PerceivedComplexity
           def on_send(node)
+            return unless node.loc.selector
+
             method_name = node.loc.selector.source
             return unless GetText.supported_method?(method_name)
 
@@ -23,6 +27,7 @@ module RuboCop
               detect_and_report(node, message_section, method_name)
             end
           end
+          # rubocop:enable Metrics/PerceivedComplexity
 
           private
 
@@ -150,6 +155,7 @@ module RuboCop
             }
           end
         end
+        # rubocop:enable Metrics/ClassLength
       end
     end
   end

--- a/lib/rubocop/cop/i18n/gettext/decorate_string_formatting_using_interpolation.rb
+++ b/lib/rubocop/cop/i18n/gettext/decorate_string_formatting_using_interpolation.rb
@@ -24,6 +24,8 @@ module RuboCop
         #
         class DecorateStringFormattingUsingInterpolation < Base
           def on_send(node)
+            return unless node.loc.selector
+
             decorator_name = node.loc.selector.source
             return unless GetText.supported_decorator?(decorator_name)
 

--- a/lib/rubocop/cop/i18n/gettext/decorate_string_formatting_using_percent.rb
+++ b/lib/rubocop/cop/i18n/gettext/decorate_string_formatting_using_percent.rb
@@ -27,6 +27,8 @@ module RuboCop
           SUPPORTED_FORMATS = %w[b B d i o u x X e E f g G a A c p s].freeze
 
           def on_send(node)
+            return unless node.loc.selector
+
             decorator_name = node.loc.selector.source
             return unless GetText.supported_decorator?(decorator_name)
 

--- a/spec/rubocop/cop/i18n/get_text/decorate_function_message_spec.rb
+++ b/spec/rubocop/cop/i18n/get_text/decorate_function_message_spec.rb
@@ -52,6 +52,10 @@ describe RuboCop::Cop::I18n::GetText::DecorateFunctionMessage, :config do
       end
     end
   end
+  context 'when using .call shorthand syntax' do
+    it_behaves_like 'accepts', 'Object.method(:to_s).()'
+  end
+
   context 'real life examples,' do
     context 'message is multiline with interpolated' do
       let(:source) { "raise(Puppet::ParseError, \"mysql_password(): Wrong number of arguments \" \\\n \"given (\#{args.size} for 1)\")" }

--- a/spec/rubocop/cop/i18n/get_text/decorate_string_formatting_using_interpolation_spec.rb
+++ b/spec/rubocop/cop/i18n/get_text/decorate_string_formatting_using_interpolation_spec.rb
@@ -5,6 +5,10 @@ describe RuboCop::Cop::I18n::GetText::DecorateStringFormattingUsingInterpolation
     @offenses = investigate(cop, source)
   end
 
+  context 'when using .call shorthand syntax' do
+    it_behaves_like 'accepts', 'Object.method(:to_s).()'
+  end
+
   RuboCop::Cop::I18n::GetText.supported_decorators.each do |decorator|
     # rubocop:disable RSpec/LeakyLocalVariable -- `error_message` is used as an argument for `it_behaves_like`.
     error_message = "function, message string should not contain \#{} formatting"

--- a/spec/rubocop/cop/i18n/get_text/decorate_string_formatting_using_percent_spec.rb
+++ b/spec/rubocop/cop/i18n/get_text/decorate_string_formatting_using_percent_spec.rb
@@ -5,6 +5,10 @@ describe RuboCop::Cop::I18n::GetText::DecorateStringFormattingUsingPercent, :con
     @offenses = investigate(cop, source)
   end
 
+  context 'when using .call shorthand syntax' do
+    it_behaves_like 'accepts', 'Object.method(:to_s).()'
+  end
+
   RuboCop::Cop::I18n::GetText.supported_decorators.each do |decorator|
     context "#{decorator} decoration not used" do
       it_behaves_like 'accepts', 'thing("a %s that is not decorated")'


### PR DESCRIPTION
The `.()` shorthand (equivalent to `.call`) caused `NoMethodError` because `node.loc.selector` is `nil` for this syntax.

Fixes #69